### PR TITLE
Improved page tree: mark selected page visually

### DIFF
--- a/themes/admin/javascript/ionize/ionize_tree_xhr.js
+++ b/themes/admin/javascript/ionize/ionize_tree_xhr.js
@@ -575,6 +575,9 @@ ION.TreeXhr = new Class({
 		// Edit Element
 		else
 		{
+			$$('#structurePanel .tree a.selected').removeClass('selected');
+			el.className = el.className + ' selected';
+			
 			var func = function()
 			{
 				ION.splitPanel({

--- a/themes/admin/styles/original/css/tree.css
+++ b/themes/admin/styles/original/css/tree.css
@@ -74,6 +74,9 @@ h3.treetitle {
 	display:block;
 	height: 18px;
 }
+.tree li a.title.selected {
+	font-weight: bold;
+}
 h3.treetitle .locked:after,
 .tree li .tree-img.no-edit:after,
 .tree li .tree-img.locked:after {


### PR DESCRIPTION
Added JS to toggle "selected" classname on clicked (and thus selected) page or article item